### PR TITLE
Fix bugged status version number

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.1'
+
+services:
+  app:
+    build: .
+    depends_on: 
+      - db
+    restart: always
+  db:
+    image: mysql
+    restart: always
+    environment:
+      MYSQL_DATABASE: tqi
+      MYSQL_USER: RaidManager4
+      MYSQL_PASSWORD: password
+      MYSQL_RANDOM_ROOT_PASSWORD: true
+    ports: 
+      - "3306:3306"
+  

--- a/util/placeholderParser.js
+++ b/util/placeholderParser.js
@@ -20,7 +20,7 @@ const PlaceholderParser = class PlaceholderParser {
   Parse = async function (String) {
     const RaidManager = this.RaidManager;
     const Placeholders = {
-      FRAMEWORK_VERSION: `${RaidManager.VERSION}`,
+      BOT_VERSION: `${RaidManager.VERSION}`,
     };
 
     for (const Key in Placeholders) {


### PR DESCRIPTION
The version number in the status is bugged, displaying `RaidManager %BOT_VERSION`. This fixes this issue and also adds an unfinished, but working docker-compose config which works well for development depending on what you're changing. The database components are still a WIP.