### PR TITLE
Persist MySQL Docker data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,4 +16,9 @@ services:
       MYSQL_RANDOM_ROOT_PASSWORD: true
     ports: 
       - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+volumes:
+  mysql-data:
   


### PR DESCRIPTION
Have the data from the MySQL Docker container persist on rebuilds and restarts.