### PR TITLE
Do not hardcode dev IDs

### DIFF
--- a/.config.example/bot/bot.toml
+++ b/.config.example/bot/bot.toml
@@ -8,6 +8,7 @@ enable_slash_commands = true
 slash_command_guilds = []
 import_requests_channel_id = "1002610487378321520"
 allow_developer_bypass = true
+developers = []
 
 [files]
 status_message_file = "status.json"

--- a/bot/util/commandInteractionHandle.js
+++ b/bot/util/commandInteractionHandle.js
@@ -16,7 +16,7 @@ module.exports = async (Bot, Interaction) => {
       if (Member.permissions.has("ADMINISTRATOR") && !Command.developer) {
         Allowed = true;
       } else if (
-        Member.id === "250805980491808768" &&
+        Bot.Configuration.commands.developers.includes(Member.id) &&
         Bot.Configuration.commands.allow_developer_bypass
       ) {
         Allowed = true;


### PR DESCRIPTION
Allow developer IDs to be configured in the `bot.toml` file. This old method essentially back doored any self-hosted instances.